### PR TITLE
Straightforward code updates to reflect the ZIO 2.0.0 API.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import Dependencies._
 import sbt.{Test, ThisBuild}
 
 lazy val scala212 = "2.12.14"
-lazy val scala213 = "2.13.6"
+lazy val scala213 = "2.13.8"
 lazy val supportedScalaVersions = List(scala212, scala213)
 
-ThisBuild / scalaVersion     := "2.13.6"
-ThisBuild / version          := "0.0.2"
+ThisBuild / scalaVersion     := "2.13.8"
+ThisBuild / version          := "0.0.3"
 ThisBuild / organization     := "io.github.mbannour"
 ThisBuild / organizationName := "mbannour"
 ThisBuild / description      := "ZIO wrapper for MongoDB Reactive Streams Java Driver"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
 
-  lazy val mongoVersion      = "4.3.1"
-  lazy val zioVersion        = "2.0.0-M1"
+  lazy val mongoVersion      = "4.7.1"
+  lazy val zioVersion        = "2.0.0"
   lazy val scalaTestVersion  = "3.2.8"
   lazy val scalaMockVersion  = "4.3.0"
   lazy val logbackVersion    = "1.1.3"

--- a/zio-core/src/main/scala/io/github/mbannour/MongoZioClient.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/MongoZioClient.scala
@@ -8,12 +8,11 @@ import org.bson.codecs.configuration.CodecRegistries.fromRegistries
 import org.bson.codecs.configuration.CodecRegistry
 import org.bson.conversions.Bson
 import org.mongodb.scala.bson.collection.immutable.Document
-import zio.{IO, Task, ZIO, ZManaged}
+import zio._
 
 import scala.jdk.CollectionConverters._
 import java.io.Closeable
 import scala.reflect.ClassTag
-
 
 case class MongoZioClient(private val wrapped: JavaMongoClient) extends Closeable {
   /**
@@ -111,7 +110,7 @@ object MongoZioClient {
   /**
     * Create an auto closable MongoZioClient instance from a connection string uri
     */
-  def autoCloseableClient(uri: String): ZManaged[Any, Throwable, MongoZioClient] = ZManaged.fromAutoCloseable(apply(uri))
+  def autoCloseableClient(uri: String): ZIO[Scope, Throwable, MongoZioClient] = ZIO.fromAutoCloseable(apply(uri))
 
   /**
     * Create a MongoZioClient instance from a connection string uri

--- a/zio-core/src/main/scala/io/github/mbannour/result/DeleteResult.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/result/DeleteResult.scala
@@ -1,7 +1,7 @@
 package io.github.mbannour.result
 
 import com.mongodb.client.result.{DeleteResult => JDeleteResult}
-import zio.{IO, Task}
+import zio._
 
 /**
   * The result of a delete operation. If the delete was unacknowledged, then {@code wasAcknowledged} will return false and all other methods
@@ -24,5 +24,5 @@ case class DeleteResult(wrapper: JDeleteResult)  {
     *
     * @return a Task of the number of documents deleted
     */
-  def getDeletedCount: Task[Long] = IO.attempt(wrapper.getDeletedCount())
+  def getDeletedCount: Task[Long] = ZIO.attempt(wrapper.getDeletedCount())
 }

--- a/zio-core/src/main/scala/io/github/mbannour/result/InsertManyResult.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/result/InsertManyResult.scala
@@ -3,7 +3,7 @@ package io.github.mbannour.result
 import scala.jdk.CollectionConverters._
 import com.mongodb.client.result.{InsertManyResult => JInsertManyResult}
 import org.bson.BsonValue
-import zio.{IO, Task}
+import zio._
 
 
 /**
@@ -29,5 +29,5 @@ case class InsertManyResult(private val wrapper: JInsertManyResult) {
     *
     * @return A Task of type map of the index of the inserted document to the id of the inserted document.
     */
-  def getInsertedIds: Task[Map[Integer, BsonValue]] = IO.attempt(wrapper.getInsertedIds.asScala.toMap)
+  def getInsertedIds: Task[Map[Integer, BsonValue]] = ZIO.attempt(wrapper.getInsertedIds.asScala.toMap)
 }

--- a/zio-core/src/main/scala/io/github/mbannour/result/UpdateResult.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/result/UpdateResult.scala
@@ -2,7 +2,7 @@ package io.github.mbannour.result
 
 import com.mongodb.client.result.{UpdateResult => JUpdateResult}
 import org.bson.BsonValue
-import zio.{IO, Task}
+import zio._
 
 /**
   * The result of an update operation.  If the update was unacknowledged, then {@code wasAcknowledged} will return false and all other
@@ -25,14 +25,14 @@ case class UpdateResult(private val wrapper: JUpdateResult) {
     *
     * @return a Task of the number of documents matched
     */
-  def getMatchedCount: Task[Long] = IO.attempt(wrapper.getMatchedCount())
+  def getMatchedCount: Task[Long] = ZIO.attempt(wrapper.getMatchedCount())
 
   /**
     * Gets the number of documents modified by the update.
     *
     * @return a Task the number of documents modified
     */
-  def getModifiedCount:Task[Long]=  IO.attempt(wrapper.getModifiedCount())
+  def getModifiedCount:Task[Long]=  ZIO.attempt(wrapper.getModifiedCount())
 
   /**
     * If the replace resulted in an inserted document, gets the _id of the inserted document, otherwise None.

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/AggregateSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/AggregateSubscription.scala
@@ -6,7 +6,7 @@ import com.mongodb.reactivestreams.client.AggregatePublisher
 import io.github.mbannour.DefaultHelper.MapTo
 import org.bson.conversions.Bson
 import org.mongodb.scala.bson.collection.immutable.Document
-import zio.IO
+import zio._
 
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
@@ -15,7 +15,7 @@ import scala.reflect.ClassTag
 case class AggregateSubscription[T](p: AggregatePublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -25,9 +25,9 @@ case class AggregateSubscription[T](p: AggregatePublisher[T]) extends Subscripti
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/CompletedSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/CompletedSubscription.scala
@@ -1,11 +1,11 @@
 package io.github.mbannour.subscriptions
 
 import io.github.mbannour.result.Completed
-import zio.IO
+import zio._
 
 case class CompletedSubscription(p: JavaPublisher[Void]) extends Subscription[Completed] {
 
-  override def fetch[_]: IO[Throwable, Completed] = IO.async[Throwable, Completed] { callback =>
+  override def fetch[_]: IO[Throwable, Completed] = ZIO.async[Any, Throwable, Completed] { callback =>
     p.subscribe {
       new JavaSubscriber[Void] {
 
@@ -13,9 +13,9 @@ case class CompletedSubscription(p: JavaPublisher[Void]) extends Subscription[Co
 
         override def onNext(t: Void): Unit = ()
 
-        override def onError(t: Throwable): Unit = callback(IO.fail(t))
+        override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-        override def onComplete(): Unit = callback(IO.succeed(Completed()))
+        override def onComplete(): Unit = callback(ZIO.succeed(Completed()))
       }
     }
   }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/DistinctSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/DistinctSubscription.scala
@@ -3,7 +3,7 @@ package io.github.mbannour.subscriptions
 import com.mongodb.client.model.Collation
 import com.mongodb.reactivestreams.client.DistinctPublisher
 import org.bson.conversions.Bson
-import zio.IO
+import zio._
 
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
@@ -11,7 +11,7 @@ import scala.collection.mutable.ArrayBuffer
 case class DistinctSubscription[T](p: DistinctPublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
           val items = new ArrayBuffer[T]()
@@ -20,9 +20,9 @@ case class DistinctSubscription[T](p: DistinctPublisher[T]) extends Subscription
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toList))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toList))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/FindSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/FindSubscription.scala
@@ -5,7 +5,7 @@ import com.mongodb.{CursorType, ExplainVerbosity}
 import com.mongodb.reactivestreams.client.FindPublisher
 import org.bson.Document
 import org.bson.conversions.Bson
-import zio.IO
+import zio._
 
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
@@ -13,7 +13,7 @@ import scala.collection.mutable.ArrayBuffer
 case class FindSubscription[T](p: FindPublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -23,9 +23,9 @@ case class FindSubscription[T](p: FindPublisher[T]) extends Subscription[Iterabl
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListCollectionsSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListCollectionsSubscription.scala
@@ -3,14 +3,14 @@ package io.github.mbannour.subscriptions
 import com.mongodb.reactivestreams.client.ListCollectionsPublisher
 import org.bson.conversions.Bson
 import org.reactivestreams.{Subscription => JSubscription}
-import zio.IO
+import zio._
 
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
 
 case class ListCollectionsSubscription[T](p: ListCollectionsPublisher[T]) extends Subscription[Iterable[T]] {
 
-  override def fetch[_]: IO[Throwable, Iterable[T]] = IO.async[Throwable, Iterable[T]] { callback =>
+  override def fetch[_]: IO[Throwable, Iterable[T]] = ZIO.async[Any, Throwable, Iterable[T]] { callback =>
     p.subscribe {
       new JavaSubscriber[T] {
 
@@ -20,9 +20,9 @@ case class ListCollectionsSubscription[T](p: ListCollectionsPublisher[T]) extend
 
         override def onNext(t: T): Unit = items += t
 
-        override def onError(t: Throwable): Unit = callback(IO.fail(t))
+        override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-        override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+        override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
       }
     }
   }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListDatabasesSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListDatabasesSubscription.scala
@@ -2,7 +2,7 @@ package io.github.mbannour.subscriptions
 
 import com.mongodb.reactivestreams.client.ListDatabasesPublisher
 import org.bson.conversions.Bson
-import zio.IO
+import zio._
 
 import java.lang
 import java.util.concurrent.TimeUnit
@@ -11,7 +11,7 @@ import scala.collection.mutable.ArrayBuffer
 case class ListDatabasesSubscription[T](p: ListDatabasesPublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -21,9 +21,9 @@ case class ListDatabasesSubscription[T](p: ListDatabasesPublisher[T]) extends Su
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListIndexesSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListIndexesSubscription.scala
@@ -1,7 +1,7 @@
 package io.github.mbannour.subscriptions
 
 import com.mongodb.reactivestreams.client.ListIndexesPublisher
-import zio.IO
+import zio._
 
 import java.util.concurrent.TimeUnit
 import scala.collection.mutable.ArrayBuffer
@@ -9,7 +9,7 @@ import scala.collection.mutable.ArrayBuffer
 case class ListIndexesSubscription[T](p: ListIndexesPublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -19,9 +19,9 @@ case class ListIndexesSubscription[T](p: ListIndexesPublisher[T]) extends Subscr
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/ListSubscription.scala
@@ -1,13 +1,13 @@
 package io.github.mbannour.subscriptions
 
-import zio.IO
+import zio._
 
 import scala.collection.mutable.ArrayBuffer
 
 case class ListSubscription[T](p: JavaPublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -17,9 +17,9 @@ case class ListSubscription[T](p: JavaPublisher[T]) extends Subscription[Iterabl
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/MapReduceSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/MapReduceSubscription.scala
@@ -3,7 +3,7 @@ package io.github.mbannour.subscriptions
 import com.mongodb.client.model.{Collation, MapReduceAction}
 import com.mongodb.reactivestreams.client.MapReducePublisher
 import org.bson.conversions.Bson
-import zio.IO
+import zio._
 
 import java.lang
 import java.util.concurrent.TimeUnit
@@ -12,7 +12,7 @@ import scala.collection.mutable.ArrayBuffer
 case class MapReduceSubscription[T](p: MapReducePublisher[T]) extends Subscription[Iterable[T]] {
 
   override def fetch[_]: IO[Throwable, Iterable[T]] =
-    IO.async[Throwable, Iterable[T]] { callback =>
+    ZIO.async[Any, Throwable, Iterable[T]] { callback =>
       p.subscribe {
         new JavaSubscriber[T] {
 
@@ -22,9 +22,9 @@ case class MapReduceSubscription[T](p: MapReducePublisher[T]) extends Subscripti
 
           override def onNext(t: T): Unit = items += t
 
-          override def onError(t: Throwable): Unit = callback(IO.fail(t))
+          override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-          override def onComplete(): Unit = callback(IO.succeed(items.toSeq))
+          override def onComplete(): Unit = callback(ZIO.succeed(items.toSeq))
         }
       }
     }

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/SingleItemSubscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/SingleItemSubscription.scala
@@ -1,10 +1,10 @@
 package io.github.mbannour.subscriptions
 
-import zio.{IO, Ref}
+import zio._
 
 case class SingleItemSubscription[T](p: JavaPublisher[T]) extends Subscription[T] {
 
-  override def fetch[_]: IO[Throwable, T] = IO.async[Throwable, T] { callback =>
+  override def fetch[_]: IO[Throwable, T] = ZIO.async[Any, Throwable, T] { callback =>
     p.subscribe {
       new JavaSubscriber[T] {
         @volatile
@@ -14,14 +14,14 @@ case class SingleItemSubscription[T](p: JavaPublisher[T]) extends Subscription[T
 
         override def onNext(t: T): Unit = item = t
 
-        override def onError(t: Throwable): Unit = callback(IO.fail(t))
+        override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-        override def onComplete(): Unit = callback(IO.succeed(item))
+        override def onComplete(): Unit = callback(ZIO.succeed(item))
       }
     }
   }
 
-  def headOption[_]: IO[Throwable, Option[T]] = IO.async[Throwable, Option[T]] { callback =>
+  def headOption[_]: IO[Throwable, Option[T]] = ZIO.async[Any, Throwable, Option[T]] { callback =>
     p.subscribe {
       new JavaSubscriber[T] {
         @volatile
@@ -31,9 +31,9 @@ case class SingleItemSubscription[T](p: JavaPublisher[T]) extends Subscription[T
 
         override def onNext(t: T): Unit = item = t
 
-        override def onError(t: Throwable): Unit = callback(IO.fail(t))
+        override def onError(t: Throwable): Unit = callback(ZIO.fail(t))
 
-        override def onComplete(): Unit = callback(IO.succeed(Option(item)))
+        override def onComplete(): Unit = callback(ZIO.succeed(Option(item)))
       }
     }
   }

--- a/zio-core/src/test/scala/io/github/mbannour/subscriptions/DistinctSubscriptionSpec.scala
+++ b/zio-core/src/test/scala/io/github/mbannour/subscriptions/DistinctSubscriptionSpec.scala
@@ -6,12 +6,12 @@ import org.mongodb.scala.bson.codecs.Macros._
 import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistries}
 import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.model.Filters
-import zio.{Duration, ExecutionStrategy}
+import zio._
 import zio.test.Assertion.equalTo
-import zio.test.environment.TestEnvironment
-import zio.test.{DefaultRunnableSpec, TestAspect, ZSpec, assertM}
+import zio.test._
+import zio.test.ZIOSpecDefault
 
-object DistinctSubscriptionSpec extends DefaultRunnableSpec {
+object DistinctSubscriptionSpec extends ZIOSpecDefault {
 
   val mongoClient = mongoTestClient()
 
@@ -21,10 +21,10 @@ object DistinctSubscriptionSpec extends DefaultRunnableSpec {
 
   val collection = database.flatMap(_.getCollection[Person]("test"))
 
-  override def aspects: List[TestAspect[Nothing, TestEnvironment, Nothing, Any]] =
-    List(TestAspect.executionStrategy(ExecutionStrategy.Sequential), TestAspect.timeout(Duration.fromMillis(30000)))
+  override def aspects =
+    Chunk(TestAspect.executionStrategy(ExecutionStrategy.Sequential), TestAspect.timeout(Duration.fromMillis(30000)))
 
-  override def spec: ZSpec[TestEnvironment, Any] = suite("DistinctSubscriptionSpec")(
+  override def spec: Spec[TestEnvironment, Any] = suite("DistinctSubscriptionSpec")(
     distinctDocuments(),
     distinctFirstDocuments(),
     filterDistinctDocuments(),
@@ -46,7 +46,7 @@ object DistinctSubscriptionSpec extends DefaultRunnableSpec {
     } yield doc
 
     test("Get distinct Persons by name") {
-      assertM(names)(equalTo(Seq("John", "Carmen", "Yasmin")))
+      assertZIO(names)(equalTo(Seq("John", "Carmen", "Yasmin")))
     }
   }
 
@@ -57,7 +57,7 @@ object DistinctSubscriptionSpec extends DefaultRunnableSpec {
     } yield doc
 
     test("Get first person Persons by name") {
-      assertM(names)(equalTo("John"))
+      assertZIO(names)(equalTo("John"))
     }
   }
 
@@ -68,7 +68,7 @@ object DistinctSubscriptionSpec extends DefaultRunnableSpec {
     } yield doc
 
     test("Get filtered persons with age greater than 30") {
-      assertM(names)(equalTo(Seq("Carmen")))
+      assertZIO(names)(equalTo(Seq("Carmen")))
     }
   }
 
@@ -80,7 +80,7 @@ object DistinctSubscriptionSpec extends DefaultRunnableSpec {
         _ <- mongoClient.pureClose()
 
       } yield ()
-      assertM(close)(equalTo(()))
+      assertZIO(close)(equalTo(()))
     }
   }
 


### PR DESCRIPTION
Main changes:

- update ZIO dependency to 2.0.0 final
- update mongo dependency to 4.3.1
- bump version to 0.0.3
- use ZIO.attempt, ZIO.succeed,, ZIO.fail etc. instead of IO
- MongoZioClient.autoCloseableClient returns a scoped ZIO rather than deprecated ZManaged
- update tests: use ZIOSpecDefault over DefaultRunnableSpec, Spec over ZSpec, assertZIO over assertM
- update example app to be a ZIOAppDefault and reflect wider changes
- update README.md to reflect wider changes