### PR TITLE
Fix headOption to handle empty iterator and add corresponding test case.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val scala213 = "2.13.10"
 lazy val supportedScalaVersions = List(scala212, scala213)
 
 ThisBuild / scalaVersion     := "2.13.8"
-ThisBuild / version          := "0.0.6"
+ThisBuild / version          := "0.0.7"
 ThisBuild / organization     := "io.github.mbannour"
 ThisBuild / organizationName := "mbannour"
 ThisBuild / description      := "ZIO wrapper for MongoDB Reactive Streams Java Driver"

--- a/zio-core/src/main/scala/io/github/mbannour/subscriptions/Subscription.scala
+++ b/zio-core/src/main/scala/io/github/mbannour/subscriptions/Subscription.scala
@@ -26,7 +26,10 @@ abstract class Subscription[T, Publisher <: JavaPublisher[T]](p: Publisher) {
 
   def toList[F[_]]: IO[Throwable, List[T]]       = fetch.map(_.toList)
   def head[F[_]]: IO[Throwable, T]               = fetch.map(_.next())
-  def headOption[F[_]]: IO[Throwable, Option[T]] = fetch.map(r => Option(r.next()))
+
+  def headOption[F[_]]: IO[Throwable, Option[T]] = fetch.map(r => {
+    if (r.hasNext) Some(r.next()) else None
+  })
 
 }
 

--- a/zio-core/src/test/scala/io/github/mbannour/subscriptions/FindSubscriptionSpec.scala
+++ b/zio-core/src/test/scala/io/github/mbannour/subscriptions/FindSubscriptionSpec.scala
@@ -27,6 +27,7 @@ object FindSubscriptionSpec extends ZIOSpecDefault {
 
   def spec: Spec[TestEnvironment, Any] = suite("FindSubscriptionSpec")(
     findOptionalFirst(),
+    findHeadOptionalFirstElement(),
     insertDocuments(),
     findAllDocuments(),
     findFirst(),
@@ -73,6 +74,18 @@ object FindSubscriptionSpec extends ZIOSpecDefault {
       assertZIO(documents.map(_.size))(equalTo(6))
     }
   }
+
+  def findHeadOptionalFirstElement() = {
+    val document = for {
+      col <- collection
+      docs <- col.find().headOption
+    } yield docs
+
+    test("Find first optional element of an empty collection should returns nothing ") {
+      assertZIO(document)(equalTo(None))
+    }
+  }
+
   def findOptionalFirst() = {
     val document = for {
       col  <- collection


### PR DESCRIPTION
Fix headOption to handle empty iterator and add corresponding test case.